### PR TITLE
holeLabel should be painted last to be visible on pie charts

### DIFF
--- a/lib/src/painter.dart
+++ b/lib/src/painter.dart
@@ -14,8 +14,8 @@ class AnimatedCircularChartPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    _paintLabel(canvas, size, labelPainter);
     _paintChart(canvas, size, animation.value);
+    _paintLabel(canvas, size, labelPainter);
   }
 
   @override
@@ -30,8 +30,8 @@ class CircularChartPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    _paintLabel(canvas, size, labelPainter);
     _paintChart(canvas, size, chart);
+    _paintLabel(canvas, size, labelPainter);
   }
 
   @override


### PR DESCRIPTION
When using holeLabel with `chartType: CircularChartType.Pie` it is not visible. 
Because it it painted first it is later overwritten by the chart. Changing painting order solves it.