### PR TITLE
Update animated_circular_chart.dart

### DIFF
--- a/lib/src/animated_circular_chart.dart
+++ b/lib/src/animated_circular_chart.dart
@@ -118,8 +118,9 @@ class AnimatedCircularChart extends StatefulWidget {
     assert(context != null);
     assert(nullOk != null);
 
-    final AnimatedCircularChartState result = context
-        .ancestorStateOfType(const TypeMatcher<AnimatedCircularChartState>());
+    
+    // ancestorStateOfType  has been depreciated
+final AnimatedCircularChartState result = context.findAncestorStateOfType<AnimatedCircularChartState>();
 
     if (nullOk || result != null) return result;
 


### PR DESCRIPTION
ancestorStateOfType has been depreciated.
final AnimatedCircularChartState result = context.ancestorStateOfType(const TypeMatcher<AnimatedCircularChartState>());
becomes:
final AnimatedCircularChartState result = context.findAncestorStateOfType<AnimatedCircularChartState>();